### PR TITLE
requiresMainQueueSetup to return NO

### DIFF
--- a/ios/ReactNativeLanguages.m
+++ b/ios/ReactNativeLanguages.m
@@ -7,7 +7,7 @@ RCT_EXPORT_MODULE();
 
 + (BOOL)requiresMainQueueSetup
 {
-  return YES;
+  return NO;
 }
 
 - (NSMutableArray *)ensureLanguageTags:(NSArray *)languages


### PR DESCRIPTION
React Native introduced the requiresMainQueueSetup from facebook/react-native@d42ccca. Per the description from the above link, react native modules that needs to be initialized on main thread is expected to return YES from requiresMainQueueSetup.

> We now require you to be explicit about the intended behaviour and implement the + (BOOL)requiresMainQueueSetup method on your module. When you return YES from this method, it tells the bridge the module needs to be created on the main thread (and to avoid deadlocks, we do so eagerly during bridge startup). When you return NO, the native module will be initialised when it's first accessed from JS.

> Most modules can be used from any thread. All of the modules exported non-sync method will be called on its
methodQueue, and the module will be constructed lazily when its first invoked. Some modules have main need to access
information that's main queue only (e.g. most UIKit classes). Since we don't want to dispatch synchronously to the
main thread to this safely, we construct these modules and export their constants ahead-of-time.

I believe this can be changed to NO.