### PR TITLE
Fix podspec so compilation works

### DIFF
--- a/RNLanguages.podspec
+++ b/RNLanguages.podspec
@@ -14,4 +14,6 @@ Pod::Spec.new do |spec|
 
   spec.source       = { :git => "https://github.com/react-community/react-native-languages.git" }
   spec.source_files = "ios/**/*.{h,m}"
+
+  spec.dependency   "React"
 end


### PR DESCRIPTION
Not sure when this broke, but this fixes compilation when used in a
project that pulls the dependency using CocoaPods 1.5.0 and Xcode 9.3

Otherwise the following error was raised by Xcode:
`React/RCTDefines.h' file not found`

See similar issue happened with react-native-firebase:
https://github.com/invertase/react-native-firebase/pull/1017